### PR TITLE
Multi-line examples rendered differently from expectation

### DIFF
--- a/lib/latexmath/converter.rb
+++ b/lib/latexmath/converter.rb
@@ -301,6 +301,9 @@ module Latexmath
         if element == '_' && index == 1 && param == '\\sum'
           new_parent.tag = 'munder'
           classify(param, new_parent)
+        elsif element == '_^' && param == '\\sum'
+          new_parent.tag = 'munderover'
+          classify(param, new_parent)
         elsif element == '\\left' || element == '\\right'
           if param == '.'
 

--- a/lib/latexmath/tokenizer.rb
+++ b/lib/latexmath/tokenizer.rb
@@ -58,9 +58,7 @@ module Latexmath
                 matched
               elsif scan(/\\\{/)
                 matched
-              elsif scan(/\\,/)
-                matched
-              elsif scan(/\\:/)
+              elsif scan(/\\[:;,]/)
                 matched
               elsif scan(/\\/)
                 matched


### PR DESCRIPTION
Fix issue:
https://github.com/plurimath/latexmath/issues/19

Updates:
- Support `\;` in Tokenizer